### PR TITLE
Cherry pick changes from #1 and #7

### DIFF
--- a/tss/keysign.go
+++ b/tss/keysign.go
@@ -219,6 +219,8 @@ func (t *TssServer) KeySign(req keysign.Request) (keysign.Response, error) {
 		t.p2pCommunication.ReleaseStream(msgID)
 		t.signatureNotifier.ReleaseStream(msgID)
 		t.partyCoordinator.ReleaseStream(msgID)
+
+		t.partyCoordinator.RemovePeerGroup(msgID)
 	}()
 
 	localStateItem, err := t.stateManager.GetLocalState(req.PoolPubKey)


### PR DESCRIPTION
Cherry pick some missing `_ = stream.Close()` from #1.

From #7:
- the switch from `_ = stream.Close()` to `_ = stream.Reset()` 
- a timeout on a channel write
- making `removePeerGroup` public and calling it during other cleanup logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved message handling for better resource management in communication streams.
	- Introduced a timeout mechanism for sending messages, enhancing error handling and logging.
	- Enhanced cleanup process for peer group management during key signing operations.

- **Bug Fixes**
	- Stream management now resets instead of closing, preventing potential unresponsive behavior.

- **Refactor**
	- Updated method naming conventions for consistency and clarity across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->