### PR TITLE
fix: wait for notifier/subscribers

### DIFF
--- a/keysign/signature_notifier_test.go
+++ b/keysign/signature_notifier_test.go
@@ -155,10 +155,16 @@ func TestSignatureNotifierBroadcastFirst(t *testing.T) {
 		p1, p2,
 	}))
 
-	n1.notifierLock.Lock()
-	assert.Contains(t, n1.notifiers, messageID)
-	notifier := n1.notifiers[messageID]
-	n1.notifierLock.Unlock()
+	var notifier *notifier
+	var ok bool
+	assert.Eventually(t, func() bool {
+		n1.notifierLock.Lock()
+		defer n1.notifierLock.Unlock()
+
+		notifier, ok = n1.notifiers[messageID]
+		return ok
+	}, time.Second, time.Millisecond*100)
+
 	assert.False(t, notifier.readyToProcess())
 	assert.Equal(t, defaultNotifierTTL, notifier.ttl)
 


### PR DESCRIPTION
Should fix this test failure:

```
--- FAIL: TestSignatureNotifierBroadcastFirst (0.06s)
    signature_notifier_test.go:159: 
        	Error Trace:	/home/runner/work/go-tss/go-tss/keysign/signature_notifier_test.go:159
        	Error:      	map[string]*keysign.notifier{} does not contain "be691deff2fbb18564d1caf54b6a37bc9951363e3151eaf542fad0c8b881d8b6"
        	Test:       	TestSignatureNotifierBroadcastFirst
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1bf0757]

goroutine 217 [running]:
testing.tRunner.func1.2({0x1d2f6a0, 0x30564c0})
	/opt/hostedtoolcache/go/1.20.14/x64/src/testing/testing.go:1526 +0x372
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.20.14/x64/src/testing/testing.go:1529 +0x650
panic({0x1d2f6a0, 0x30564c0})
	/opt/hostedtoolcache/go/1.20.14/x64/src/runtime/panic.go:890 +0x263
gitlab.com/thorchain/tss/go-tss/keysign.(*notifier).readyToProcess(0x0)
	/home/runner/work/go-tss/go-tss/keysign/notifier.go:53 +0x37
gitlab.com/thorchain/tss/go-tss/keysign.TestSignatureNotifierBroadcastFirst(0xc0004f7380)
	/home/runner/work/go-tss/go-tss/keysign/signature_notifier_test.go:162 +0xd26
testing.tRunner(0xc0004f7380, 0x22d5208)
	/opt/hostedtoolcache/go/1.20.14/x64/src/testing/testing.go:1576 +0x217
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.20.14/x64/src/testing/testing.go:1629 +0x806
FAIL	gitlab.com/thorchain/tss/go-tss/keysign	1.288s
```