### PR TITLE
shut down dht after 5 mins

### DIFF
--- a/p2p/communication.go
+++ b/p2p/communication.go
@@ -338,6 +338,20 @@ func (c *Communication) startChannel(privKeyBytes []byte) error {
 	// This is like telling your friends to meet you at the Eiffel Tower.
 	routingDiscovery := discovery_routing.NewRoutingDiscovery(kademliaDHT)
 	discovery_util.Advertise(ctx, routingDiscovery, c.rendezvous)
+
+	// Create a goroutine to shut down the DHT after 5 minutes
+	go func() {
+		select {
+		case <-time.After(5 * time.Minute):
+			c.logger.Info().Msg("Closing Kademlia DHT after 5 minutes")
+			if err := kademliaDHT.Close(); err != nil {
+				c.logger.Error().Err(err).Msg("Failed to close Kademlia DHT")
+			}
+		case <-ctx.Done():
+			c.logger.Info().Msg("Context done, not waiting for 5 minutes to close DHT")
+		}
+	}()
+
 	err = c.bootStrapConnectivityCheck()
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management by ensuring the Kademlia DHT shuts down after 5 minutes.
	- Enhanced logging for better clarity during error handling and connection establishment.

- **Chores**
	- Minor adjustments to logging messages for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->