### PR TITLE
Use separate file for address book store

### DIFF
--- a/keysign/ecdsa/keysign_old_test.go
+++ b/keysign/ecdsa/keysign_old_test.go
@@ -77,6 +77,10 @@ func (s *MockLocalStateOldManager) SaveAddressBook(address map[peer.ID][]maddr.M
 	return nil
 }
 
+func (s *MockLocalStateOldManager) RetrieveBootstrapAddresses() ([]maddr.Multiaddr, error) {
+	return nil, os.ErrNotExist
+}
+
 func (s *MockLocalStateOldManager) RetrieveP2PAddresses() ([]maddr.Multiaddr, error) {
 	return nil, os.ErrNotExist
 }

--- a/keysign/ecdsa/keysign_test.go
+++ b/keysign/ecdsa/keysign_test.go
@@ -89,6 +89,10 @@ func (s *MockLocalStateManager) SaveAddressBook(address map[peer.ID][]maddr.Mult
 	return nil
 }
 
+func (s *MockLocalStateManager) RetrieveBootstrapAddresses() ([]maddr.Multiaddr, error) {
+	return nil, os.ErrNotExist
+}
+
 func (s *MockLocalStateManager) RetrieveP2PAddresses() ([]maddr.Multiaddr, error) {
 	return nil, os.ErrNotExist
 }

--- a/keysign/eddsa/keysign_test.go
+++ b/keysign/eddsa/keysign_test.go
@@ -85,6 +85,10 @@ func (s *MockLocalStateManager) SaveAddressBook(address map[peer.ID][]maddr.Mult
 	return nil
 }
 
+func (s *MockLocalStateManager) RetrieveBootstrapAddresses() ([]maddr.Multiaddr, error) {
+	return nil, os.ErrNotExist
+}
+
 func (s *MockLocalStateManager) RetrieveP2PAddresses() ([]maddr.Multiaddr, error) {
 	return nil, os.ErrNotExist
 }

--- a/storage/localstate_mgr_test.go
+++ b/storage/localstate_mgr_test.go
@@ -95,7 +95,7 @@ func (s *FileStateMgrTestSuite) TestSaveAddressBook(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(fsm, NotNil)
 	c.Assert(fsm.SaveAddressBook(testAddresses), IsNil)
-	filePathName := filepath.Join(f, "address_book.seed")
+	filePathName := filepath.Join(f, addressBookName)
 	_, err = os.Stat(filePathName)
 	c.Assert(err, IsNil)
 	item, err := fsm.RetrieveP2PAddresses()

--- a/storage/mock_localstatemanager.go
+++ b/storage/mock_localstatemanager.go
@@ -21,6 +21,10 @@ func (s *MockLocalStateManager) SaveAddressBook(address map[peer.ID][]maddr.Mult
 	return nil
 }
 
+func (s *MockLocalStateManager) RetrieveBootstrapAddresses() ([]maddr.Multiaddr, error) {
+	return nil, nil
+}
+
 func (s *MockLocalStateManager) RetrieveP2PAddresses() ([]maddr.Multiaddr, error) {
 	return nil, nil
 }

--- a/tss/tss.go
+++ b/tss/tss.go
@@ -80,7 +80,7 @@ func NewTss(
 	}
 
 	var bootstrapPeers []maddr.Multiaddr
-	savedPeers, err := stateManager.RetrieveP2PAddresses()
+	savedPeers, err := stateManager.RetrieveBootstrapAddresses()
 	if err != nil {
 		bootstrapPeers = cmdBootstrapPeers
 	} else {


### PR DESCRIPTION
Use separate files for the seed and saved state of the address book to allow for managing the address_book.seed under configuration control.

Both files will be loaded by `RetrieveP2PAddresses()` but `SaveAddressBook()` will only write to `address_book`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced address book management with improved state retrieval functionalities.
	- Introduced a new method for loading bootstrap addresses, ensuring better error handling and data integrity.
	- Updated the peer discovery process to utilize bootstrap addresses.

- **Bug Fixes**
	- Improved error reporting for invalid addresses during retrieval.

- **Tests**
	- Updated test cases to use a dynamic approach for file path construction related to the address book.
	- Added new methods for retrieving bootstrap addresses in mock state managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->