### PR TITLE
CI: remove go 1.20 unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go-version: ["1.20", "1.22"]
+        go-version: ["1.22"]
     name: test go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
it's not needed anymore and it lacks generics (specifically the slices package)