### PR TITLE
fix infinite discovery address leak

### DIFF
--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"slices"
 	"sync"
 	"time"
 
@@ -85,7 +84,7 @@ func (pd *PeerDiscovery) addPeer(pinfo peer.AddrInfo) {
 	oldPinfo, ok := pd.knownPeers[pinfo.ID]
 	if ok {
 		for _, addr := range pinfo.Addrs {
-			if !slices.Contains(oldPinfo.Addrs, addr) {
+			if !multiaddr.Contains(oldPinfo.Addrs, addr) {
 				oldPinfo.Addrs = append(oldPinfo.Addrs, addr)
 			}
 		}

--- a/p2p/discovery_test.go
+++ b/p2p/discovery_test.go
@@ -83,4 +83,9 @@ func TestDiscovery(t *testing.T) {
 	assert.Equal(t, 4, len(comm2.host.Peerstore().Peers()))
 	assert.Equal(t, 4, len(comm3.host.Peerstore().Peers()))
 	assert.Equal(t, 4, len(comm4.host.Peerstore().Peers()))
+
+	assert.Equal(t, 3, len(comm.discovery.knownPeers))
+	for peer, knownPeers := range comm.discovery.knownPeers {
+		assert.LessOrEqual(t, len(knownPeers.Addrs), 4, "%s has more than 4 addresses (%d)?", peer.String(), len(knownPeers.Addrs))
+	}
 }

--- a/p2p/discovery_test.go
+++ b/p2p/discovery_test.go
@@ -84,8 +84,10 @@ func TestDiscovery(t *testing.T) {
 	assert.Equal(t, 4, len(comm3.host.Peerstore().Peers()))
 	assert.Equal(t, 4, len(comm4.host.Peerstore().Peers()))
 
+	comm.discovery.mu.Lock()
 	assert.Equal(t, 3, len(comm.discovery.knownPeers))
 	for peer, knownPeers := range comm.discovery.knownPeers {
 		assert.LessOrEqual(t, len(knownPeers.Addrs), 4, "%s has more than 4 addresses (%d)?", peer.String(), len(knownPeers.Addrs))
 	}
+	comm.discovery.mu.Unlock()
 }


### PR DESCRIPTION
In the zetaclient logs, you'll see spam of thousands of addresses and OOM crashes

Add unit test to detect this scenario. `master` fails like this:

```
discovery_test.go:89:
        	Error Trace:	/Users/alex/workspace/github.com/zeta-chain/go-tss/p2p/discovery_test.go:89
        	Error:      	"5034" is not less than or equal to "4"
        	Test:       	TestDiscovery
        	Messages:   	16Uiu2HAm2BvdrtKF4TQQ51gajCZhYnqkUi99NZ2eCL25dXUxeEKA has more than 4 addresses (5034)?
```

`slices.Compare` apparently doesn't actually work on `multiaddr.Multiaddr` apparently. So the addresses are appended until the process runs out of memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved address checking logic for peer discovery to ensure accurate tracking of known addresses.

- **Tests**
	- Enhanced the `TestDiscovery` function with additional assertions to verify the state of known peers and enforce limits on the number of addresses per peer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->