### PR TITLE
refactor(stream): improve deadlines

### DIFF
--- a/keysign/signature_notifier_test.go
+++ b/keysign/signature_notifier_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zeta-chain/go-tss/conversion"
 
 	"github.com/zeta-chain/go-tss/common"
-	"github.com/zeta-chain/go-tss/p2p"
 )
 
 func TestSignatureNotifierHappyPath(t *testing.T) {
@@ -31,7 +30,6 @@ func TestSignatureNotifierHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	messageID, err := common.MsgToHashString(buf)
 	assert.NoError(t, err)
-	p2p.ApplyDeadline.Store(false)
 	id1 := tnet.RandIdentityOrFatal(t)
 	id2 := tnet.RandIdentityOrFatal(t)
 	id3 := tnet.RandIdentityOrFatal(t)
@@ -104,7 +102,6 @@ func TestSignatureNotifierBroadcastFirst(t *testing.T) {
 	assert.NoError(t, err)
 	messageID, err := common.MsgToHashString(buf)
 	assert.NoError(t, err)
-	p2p.ApplyDeadline.Store(false)
 	id1 := tnet.RandIdentityOrFatal(t)
 	id2 := tnet.RandIdentityOrFatal(t)
 	id3 := tnet.RandIdentityOrFatal(t)

--- a/p2p/mocks/stream.go
+++ b/p2p/mocks/stream.go
@@ -1,0 +1,217 @@
+package mocks
+
+import (
+	"bytes"
+	"math/rand/v2"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+const testProtocolID protocol.ID = "/p2p/test-stream"
+
+type Stream struct {
+	t      *testing.T
+	buffer *bytes.Buffer
+
+	id       uint64
+	protocol protocol.ID
+
+	readDeadline  time.Time
+	writeDeadline time.Time
+
+	errSetReadDeadLine  bool
+	errSetWriteDeadLine bool
+	errRead             bool
+
+	mu *sync.RWMutex
+}
+
+var _ network.Stream = &Stream{}
+
+func NewStream(t *testing.T) *Stream {
+	return &Stream{
+		t:      t,
+		buffer: &bytes.Buffer{},
+
+		id:       rand.Uint64() % 10_000,
+		protocol: testProtocolID,
+
+		readDeadline:  time.Time{},
+		writeDeadline: time.Time{},
+
+		errSetReadDeadLine:  false,
+		errSetWriteDeadLine: false,
+		errRead:             false,
+
+		mu: &sync.RWMutex{},
+	}
+}
+
+func (s *Stream) Read(buf []byte) (n int, err error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.errRead {
+		return 0, errors.New("you asked for it")
+	}
+
+	// no deadline, read immediately (sync)
+	if s.readDeadline.IsZero() {
+		return s.buffer.Read(buf)
+	}
+
+	var (
+		timeout = time.Until(s.readDeadline)
+		done    = make(chan struct{})
+	)
+
+	go func() {
+		n, err = s.buffer.Read(buf)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return n, err
+	case <-time.After(timeout):
+		return 0, errors.New("mock: read deadline exceeded")
+	}
+}
+
+func (s *Stream) MustRead(buf []byte) {
+	_, err := s.Read(buf)
+	require.NoError(s.t, err, "failed to read from stream")
+}
+
+func (s *Stream) Write(buf []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.errSetWriteDeadLine {
+		return 0, errors.New("mock: unable to set write deadline")
+	}
+
+	// no deadline, write immediately (sync)
+	if s.writeDeadline.IsZero() {
+		return s.buffer.Write(buf)
+	}
+
+	var (
+		timeout = time.Until(s.writeDeadline)
+		done    = make(chan struct{})
+	)
+
+	go func() {
+		n, err = s.buffer.Write(buf)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return n, err
+	case <-time.After(timeout):
+		return 0, errors.New("mock: write deadline exceeded")
+	}
+}
+
+func (s *Stream) MustWrite(buf []byte) {
+	_, err := s.Write(buf)
+	require.NoError(s.t, err, "failed to write to stream")
+}
+
+func (s *Stream) Stat() network.Stats {
+	return network.Stats{
+		Direction: network.DirUnknown,
+		Extra:     make(map[any]any),
+	}
+}
+
+func (s *Stream) Protocol() protocol.ID {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.protocol
+}
+
+func (s *Stream) SetProtocol(id protocol.ID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.protocol = id
+
+	return nil
+}
+
+func (s *Stream) SetDeadline(at time.Time) error {
+	if err := s.SetReadDeadline(at); err != nil {
+		return err
+	}
+
+	if err := s.SetWriteDeadline(at); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Stream) SetReadDeadline(at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.errSetReadDeadLine {
+		return errors.New("mock: unable to set read deadline")
+	}
+
+	s.readDeadline = at
+
+	return nil
+}
+
+func (s *Stream) SetWriteDeadline(at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.errSetWriteDeadLine {
+		return errors.New("mock: unable to set write deadline")
+	}
+
+	s.writeDeadline = at
+
+	return nil
+}
+
+func (s *Stream) ErrRead(v bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.errRead = v
+}
+
+func (s *Stream) ErrSetReadDeadline(v bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.errSetReadDeadLine = v
+}
+
+func (s *Stream) ErrSetWriteDeadline(v bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.errSetWriteDeadLine = v
+}
+
+func (s *Stream) ID() string                 { return strconv.FormatUint(s.id, 10) }
+func (s *Stream) Scope() network.StreamScope { return &network.NullScope{} }
+func (s *Stream) Conn() network.Conn         { return nil }
+func (s *Stream) Close() error               { return nil }
+func (s *Stream) CloseRead() error           { return nil }
+func (s *Stream) CloseWrite() error          { return nil }
+func (s *Stream) Reset() error               { return nil }

--- a/p2p/party_coordinator_test.go
+++ b/p2p/party_coordinator_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/zeta-chain/go-tss/conversion"
 )
 
-func init() {
-	ApplyDeadline.Store(false)
-}
-
 func setupHosts(t *testing.T, n int) []host.Host {
 	mn := mocknet.New()
 


### PR DESCRIPTION
This PR eliminates global `init()` and `ApplyDeadline` in `p2p` package, improves stream mock,s and converges code paths between unit tests and real code execution

Closes https://github.com/zeta-chain/go-tss/issues/55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new mock stream implementation for testing, providing enhanced control over simulated network stream behavior.

- **Refactor**
  - Centralized and simplified deadline handling for network streams, removing global flags and improving error handling.
  - Replaced custom mock stream implementations in tests with the new standardized mock stream for consistency and maintainability.

- **Chores**
  - Removed obsolete initialization and test code related to the previous deadline application logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->