### PR TITLE
refactor: organize time-related consts

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -25,6 +25,7 @@ const PartyJoinMemberRetryInterval = 500 * time.Millisecond
 const (
 	SigNotifierCleanupInterval = 15 * time.Second
 	SigNotifierTTL             = 30 * time.Second
+	SigNotifierAckTimeout      = 2 * time.Second
 )
 
 // ScalingLimits creates a config for libp2p scaling limits

--- a/config/const.go
+++ b/config/const.go
@@ -1,0 +1,12 @@
+// Package config contains the constants for the TSS library
+package config
+
+import "time"
+
+// stream-related constants
+const (
+	StreamTimeoutConnect = 20 * time.Second
+	StreamTimeoutRead    = 20 * time.Second
+	StreamTimeoutWrite   = 20 * time.Second
+	StreamMaxPayload     = 1024 * 1024 * 10 // 20MB
+)

--- a/config/const.go
+++ b/config/const.go
@@ -1,7 +1,13 @@
 // Package config contains the constants for the TSS library
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	resources "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+)
 
 // stream-related constants
 const (
@@ -10,3 +16,44 @@ const (
 	StreamTimeoutWrite   = 20 * time.Second
 	StreamMaxPayload     = 1024 * 1024 * 10 // 20MB
 )
+
+const StreamManagerMaxAgeBeforeCleanup = time.Minute
+
+// ScalingLimits creates a config for libp2p scaling limits
+func ScalingLimits(protocols ...protocol.ID) resources.ConcreteLimitConfig {
+	limits := resources.DefaultLimits
+
+	base := resources.BaseLimit{
+		Streams:         4096,
+		StreamsInbound:  2048,
+		StreamsOutbound: 2048,
+		Memory:          mb(512),
+	}
+
+	increase := resources.BaseLimitIncrease{
+		Streams:         512,
+		StreamsInbound:  256,
+		StreamsOutbound: 256,
+		Memory:          mb(64),
+	}
+
+	limits.ProtocolBaseLimit = base
+	limits.ProtocolLimitIncrease = increase
+
+	for _, protocol := range protocols {
+		limits.AddProtocolLimit(protocol, base, increase)
+		limits.AddProtocolPeerLimit(protocol, base, increase)
+	}
+
+	// Add limits around included libp2p protocols
+	libp2p.SetDefaultServiceLimits(&limits)
+
+	// Turn the scaling limits into a static set of limits using `.AutoScale`. This
+	// scales the limits proportional to system's memory.
+	return limits.AutoScale()
+}
+
+// mb converts a number of megabytes to bytes
+func mb(n int64) int64 {
+	return n << 20
+}

--- a/config/const.go
+++ b/config/const.go
@@ -9,24 +9,37 @@ import (
 	resources "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 )
 
-// stream-related constants
+// Stream related constants
 const (
-	StreamTimeoutConnect             = 20 * time.Second
-	StreamTimeoutRead                = 20 * time.Second
-	StreamTimeoutWrite               = 20 * time.Second
-	StreamMaxPayload                 = 1024 * 1024 * 10 // 20MB
-	StreamManagerMaxAgeBeforeCleanup = time.Minute
+	// We allow this duration to connect to the peer
+	StreamTimeoutConnect = 10 * time.Second
+
+	// We allow this duration to read from the stream
+	StreamTimeoutRead = 20 * time.Second
+
+	// We allow this duration to write to the stream
+	StreamTimeoutWrite = 20 * time.Second
+
+	// Cleanup interval && TTL for "waste" streams (aka streams that are not used)
+	StreamExcessTTL = 1 * time.Minute
+
+	// Max payload for a stream in bytes. 20MB
+	StreamMaxPayload = 20 << 20
+)
+
+// Signature Notifier related constants
+const (
+	// We allow this duration to receive ACK back from the peer
+	SigNotifierAckTimeout = 2 * time.Second
+
+	// Notifier tll. Will be cleaned up if no response from the peer
+	SigNotifierTTL             = 30 * time.Second
+	SigNotifierCleanupInterval = 15 * time.Second
 )
 
 const TSSCommonFinalTimeout = 5 * time.Second
 
 const PartyJoinMemberRetryInterval = 500 * time.Millisecond
-
-const (
-	SigNotifierCleanupInterval = 15 * time.Second
-	SigNotifierTTL             = 30 * time.Second
-	SigNotifierAckTimeout      = 2 * time.Second
-)
 
 // ScalingLimits creates a config for libp2p scaling limits
 func ScalingLimits(protocols ...protocol.ID) resources.ConcreteLimitConfig {

--- a/config/const.go
+++ b/config/const.go
@@ -22,6 +22,11 @@ const TSSCommonFinalTimeout = 5 * time.Second
 
 const PartyJoinMemberRetryInterval = 500 * time.Millisecond
 
+const (
+	SigNotifierCleanupInterval = 15 * time.Second
+	SigNotifierTTL             = 30 * time.Second
+)
+
 // ScalingLimits creates a config for libp2p scaling limits
 func ScalingLimits(protocols ...protocol.ID) resources.ConcreteLimitConfig {
 	limits := resources.DefaultLimits

--- a/config/const.go
+++ b/config/const.go
@@ -11,15 +11,16 @@ import (
 
 // stream-related constants
 const (
-	StreamTimeoutConnect = 20 * time.Second
-	StreamTimeoutRead    = 20 * time.Second
-	StreamTimeoutWrite   = 20 * time.Second
-	StreamMaxPayload     = 1024 * 1024 * 10 // 20MB
+	StreamTimeoutConnect             = 20 * time.Second
+	StreamTimeoutRead                = 20 * time.Second
+	StreamTimeoutWrite               = 20 * time.Second
+	StreamMaxPayload                 = 1024 * 1024 * 10 // 20MB
+	StreamManagerMaxAgeBeforeCleanup = time.Minute
 )
 
-const StreamManagerMaxAgeBeforeCleanup = time.Minute
-
 const TSSCommonFinalTimeout = 5 * time.Second
+
+const PartyJoinMemberRetryInterval = 500 * time.Millisecond
 
 // ScalingLimits creates a config for libp2p scaling limits
 func ScalingLimits(protocols ...protocol.ID) resources.ConcreteLimitConfig {

--- a/config/const.go
+++ b/config/const.go
@@ -9,36 +9,37 @@ import (
 	resources "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 )
 
-// Stream related constants
 const (
-	// We allow this duration to connect to the peer
+	// StreamTimeoutConnect allow this duration to connect to the peer
 	StreamTimeoutConnect = 10 * time.Second
 
-	// We allow this duration to read from the stream
+	// StreamTimeoutRead allow this duration to read from the stream
 	StreamTimeoutRead = 20 * time.Second
 
-	// We allow this duration to write to the stream
+	// StreamTimeoutWrite allow this duration to write to the stream
 	StreamTimeoutWrite = 20 * time.Second
 
-	// Cleanup interval && TTL for "waste" streams (aka streams that are not used)
+	// StreamExcessTTL is the cleanup interval && TTL for "waste" streams (aka streams that are not used)
 	StreamExcessTTL = 1 * time.Minute
 
-	// Max payload for a stream in bytes. 20MB
+	// StreamMaxPayload is the max payload for a stream in bytes. 20MB
 	StreamMaxPayload = 20 << 20
 )
 
 // Signature Notifier related constants
 const (
-	// We allow this duration to receive ACK back from the peer
+	// SigNotifierAckTimeout is the duration to receive ACK back from the peer
 	SigNotifierAckTimeout = 2 * time.Second
 
-	// Notifier tll. Will be cleaned up if no response from the peer
+	// SigNotifierTTL is the TTL for the notifier. Will be cleaned up if no response from the peer
 	SigNotifierTTL             = 30 * time.Second
 	SigNotifierCleanupInterval = 15 * time.Second
 )
 
+// TSSCommonFinalTimeout is the graceful timeout for keygen/keysign finalization
 const TSSCommonFinalTimeout = 5 * time.Second
 
+// PartyJoinMemberRetryInterval retry interval for joining keygen/keysign party
 const PartyJoinMemberRetryInterval = 500 * time.Millisecond
 
 // ScalingLimits creates a config for libp2p scaling limits

--- a/config/const.go
+++ b/config/const.go
@@ -19,6 +19,8 @@ const (
 
 const StreamManagerMaxAgeBeforeCleanup = time.Minute
 
+const TSSCommonFinalTimeout = 5 * time.Second
+
 // ScalingLimits creates a config for libp2p scaling limits
 func ScalingLimits(protocols ...protocol.ID) resources.ConcreteLimitConfig {
 	limits := resources.DefaultLimits

--- a/keygen/ecdsa/tss_keygen.go
+++ b/keygen/ecdsa/tss_keygen.go
@@ -151,6 +151,7 @@ func (kg *Keygen) GenerateNewKey(req keygen.Request) (*bcrypto.ECPoint, error) {
 	}
 
 	select {
+	// TODO MOVE to const
 	case <-time.After(time.Second * 5):
 		close(kg.commStopChan)
 	case <-kg.tssCommonStruct.GetTaskDone():

--- a/keygen/ecdsa/tss_keygen.go
+++ b/keygen/ecdsa/tss_keygen.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/zeta-chain/go-tss/blame"
 	"github.com/zeta-chain/go-tss/common"
+	"github.com/zeta-chain/go-tss/config"
 	"github.com/zeta-chain/go-tss/conversion"
 	"github.com/zeta-chain/go-tss/keygen"
 	"github.com/zeta-chain/go-tss/logs"
@@ -151,8 +152,7 @@ func (kg *Keygen) GenerateNewKey(req keygen.Request) (*bcrypto.ECPoint, error) {
 	}
 
 	select {
-	// TODO MOVE to const
-	case <-time.After(time.Second * 5):
+	case <-time.After(config.TSSCommonFinalTimeout):
 		close(kg.commStopChan)
 	case <-kg.tssCommonStruct.GetTaskDone():
 		close(kg.commStopChan)

--- a/keygen/eddsa/tss_keygen.go
+++ b/keygen/eddsa/tss_keygen.go
@@ -142,6 +142,7 @@ func (kg *Keygen) GenerateNewKey(req keygen.Request) (*bcrypto.ECPoint, error) {
 	}
 
 	select {
+	// TODO MOVE to const && Investigate why 5 seconds???
 	case <-time.After(time.Second * 5):
 		close(kg.commStopChan)
 

--- a/keygen/eddsa/tss_keygen.go
+++ b/keygen/eddsa/tss_keygen.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/zeta-chain/go-tss/blame"
 	"github.com/zeta-chain/go-tss/common"
+	"github.com/zeta-chain/go-tss/config"
 	"github.com/zeta-chain/go-tss/conversion"
 	"github.com/zeta-chain/go-tss/keygen"
 	"github.com/zeta-chain/go-tss/logs"
@@ -142,10 +143,8 @@ func (kg *Keygen) GenerateNewKey(req keygen.Request) (*bcrypto.ECPoint, error) {
 	}
 
 	select {
-	// TODO MOVE to const && Investigate why 5 seconds???
-	case <-time.After(time.Second * 5):
+	case <-time.After(config.TSSCommonFinalTimeout):
 		close(kg.commStopChan)
-
 	case <-kg.tssCommonStruct.GetTaskDone():
 		close(kg.commStopChan)
 	}

--- a/keysign/ecdsa/tss_keysign.go
+++ b/keysign/ecdsa/tss_keysign.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/zeta-chain/go-tss/blame"
 	"github.com/zeta-chain/go-tss/common"
+	"github.com/zeta-chain/go-tss/config"
 	"github.com/zeta-chain/go-tss/conversion"
 	"github.com/zeta-chain/go-tss/logs"
 	"github.com/zeta-chain/go-tss/messages"
@@ -207,8 +208,7 @@ func (tKeySign *TssKeySign) SignMessage(
 	}
 
 	select {
-	// TODO MOVE to const && Investigate why 5 seconds???
-	case <-time.After(time.Second * 5):
+	case <-time.After(config.TSSCommonFinalTimeout):
 		close(tKeySign.commStopChan)
 	case <-tKeySign.tssCommonStruct.GetTaskDone():
 		close(tKeySign.commStopChan)

--- a/keysign/ecdsa/tss_keysign.go
+++ b/keysign/ecdsa/tss_keysign.go
@@ -207,6 +207,7 @@ func (tKeySign *TssKeySign) SignMessage(
 	}
 
 	select {
+	// TODO MOVE to const && Investigate why 5 seconds???
 	case <-time.After(time.Second * 5):
 		close(tKeySign.commStopChan)
 	case <-tKeySign.tssCommonStruct.GetTaskDone():

--- a/keysign/eddsa/tss_keysign.go
+++ b/keysign/eddsa/tss_keysign.go
@@ -194,6 +194,7 @@ func (tKeySign *KeySign) SignMessage(
 	}
 
 	select {
+	// TODO MOVE & Investigate why 5 seconds???
 	case <-time.After(time.Second * 5):
 		close(tKeySign.commStopChan)
 	case <-tKeySign.tssCommonStruct.GetTaskDone():

--- a/keysign/eddsa/tss_keysign.go
+++ b/keysign/eddsa/tss_keysign.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/zeta-chain/go-tss/blame"
 	"github.com/zeta-chain/go-tss/common"
+	"github.com/zeta-chain/go-tss/config"
 	"github.com/zeta-chain/go-tss/conversion"
 	"github.com/zeta-chain/go-tss/logs"
 	"github.com/zeta-chain/go-tss/messages"
@@ -194,8 +195,7 @@ func (tKeySign *KeySign) SignMessage(
 	}
 
 	select {
-	// TODO MOVE & Investigate why 5 seconds???
-	case <-time.After(time.Second * 5):
+	case <-time.After(config.TSSCommonFinalTimeout):
 		close(tKeySign.commStopChan)
 	case <-tKeySign.tssCommonStruct.GetTaskDone():
 		close(tKeySign.commStopChan)

--- a/keysign/notifier.go
+++ b/keysign/notifier.go
@@ -13,10 +13,9 @@ import (
 	"github.com/decred/dcrd/dcrec/edwards/v2"
 	"github.com/pkg/errors"
 	"github.com/tendermint/btcd/btcec"
-)
 
-// TODO MOVE to const
-const defaultNotifierTTL = time.Second * 30
+	"github.com/zeta-chain/go-tss/config"
+)
 
 // notifier is design to receive keysign signature, success or failure
 type notifier struct {
@@ -49,7 +48,7 @@ func newNotifier(
 		signatures:  signatures,
 		resp:        make(chan []*common.SignatureData, 1),
 		lastUpdated: time.Now(),
-		ttl:         defaultNotifierTTL,
+		ttl:         config.SigNotifierTTL,
 		lock:        sync.RWMutex{},
 	}, nil
 }

--- a/keysign/notifier.go
+++ b/keysign/notifier.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tendermint/btcd/btcec"
 )
 
+// TODO MOVE to const
 const defaultNotifierTTL = time.Second * 30
 
 // notifier is design to receive keysign signature, success or failure

--- a/keysign/signature_notifier.go
+++ b/keysign/signature_notifier.go
@@ -209,8 +209,7 @@ func (s *SignatureNotifier) sendOneMsgToPeer(m *signatureItem) error {
 	}
 
 	// We allow this duration to receive ACK back from the peer
-	ackDeadline := time.Now().Add(config.SigNotifierAckTimeout)
-	if err := stream.SetReadDeadline(ackDeadline); nil != err {
+	if err := p2p.ApplyDeadline(stream, config.SigNotifierAckTimeout, true); err != nil {
 		return errors.Wrapf(err, "fail to set read deadline to stream")
 	}
 

--- a/keysign/signature_notifier.go
+++ b/keysign/signature_notifier.go
@@ -53,7 +53,7 @@ func NewSignatureNotifier(host host.Host, logger zerolog.Logger) *SignatureNotif
 		host:         host,
 		notifierLock: &sync.Mutex{},
 		notifiers:    make(map[string]*notifier),
-		streamMgr:    p2p.NewStreamManager(logger, config.StreamManagerMaxAgeBeforeCleanup),
+		streamMgr:    p2p.NewStreamManager(logger, config.StreamExcessTTL),
 		logger:       logger,
 	}
 

--- a/keysign/signature_notifier.go
+++ b/keysign/signature_notifier.go
@@ -208,9 +208,9 @@ func (s *SignatureNotifier) sendOneMsgToPeer(m *signatureItem) error {
 		return errors.Wrapf(err, "fail to write KeysignSignature to stream")
 	}
 
-	// we wait for 1 second to allow the receive notify us
-	// TODO MOVE to const
-	if err := stream.SetReadDeadline(time.Now().Add(time.Second * 1)); nil != err {
+	// We allow this duration to receive ACK back from the peer
+	ackDeadline := time.Now().Add(config.SigNotifierAckTimeout)
+	if err := stream.SetReadDeadline(ackDeadline); nil != err {
 		return errors.Wrapf(err, "fail to set read deadline to stream")
 	}
 

--- a/keysign/signature_notifier.go
+++ b/keysign/signature_notifier.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
+	"github.com/zeta-chain/go-tss/config"
 	"github.com/zeta-chain/go-tss/logs"
 	"github.com/zeta-chain/go-tss/messages"
 	"github.com/zeta-chain/go-tss/p2p"
@@ -52,7 +53,7 @@ func NewSignatureNotifier(host host.Host, logger zerolog.Logger) *SignatureNotif
 		host:         host,
 		notifierLock: &sync.Mutex{},
 		notifiers:    make(map[string]*notifier),
-		streamMgr:    p2p.NewStreamManager(logger),
+		streamMgr:    p2p.NewStreamManager(logger, config.StreamManagerMaxAgeBeforeCleanup),
 		logger:       logger,
 	}
 
@@ -86,6 +87,7 @@ func (s *SignatureNotifier) cleanupStaleNotifiers() {
 		}
 		s.notifierLock.Unlock()
 	}
+	// TODO MOVE to const && add logs how many cleaned
 	ticker := time.NewTicker(time.Second * 15)
 	defer ticker.Stop()
 
@@ -156,6 +158,7 @@ func (s *SignatureNotifier) handleStream(stream network.Stream) {
 }
 
 func (s *SignatureNotifier) sendOneMsgToPeer(m *signatureItem) error {
+	// TODO MOVE to const
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 
@@ -199,6 +202,7 @@ func (s *SignatureNotifier) sendOneMsgToPeer(m *signatureItem) error {
 	}
 
 	// we wait for 1 second to allow the receive notify us
+	// TODO MOVE to const
 	if err := stream.SetReadDeadline(time.Now().Add(time.Second * 1)); nil != err {
 		return errors.Wrapf(err, "fail to set read deadline to stream")
 	}

--- a/keysign/signature_notifier.go
+++ b/keysign/signature_notifier.go
@@ -158,8 +158,7 @@ func (s *SignatureNotifier) handleStream(stream network.Stream) {
 }
 
 func (s *SignatureNotifier) sendOneMsgToPeer(m *signatureItem) error {
-	// TODO MOVE to const
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	ctx, cancel := context.WithTimeout(context.Background(), config.StreamTimeoutConnect)
 	defer cancel()
 
 	stream, err := s.host.NewStream(ctx, m.peerID, p2p.ProtocolSignatureNotifier)

--- a/keysign/signature_notifier.go
+++ b/keysign/signature_notifier.go
@@ -159,7 +159,7 @@ func (s *SignatureNotifier) handleStream(stream network.Stream) {
 		signatures = append(signatures, &signature)
 	}
 
-	_, err = s.createOrUpdateNotifier(msg.ID, nil, "", signatures, defaultNotifierTTL)
+	_, err = s.createOrUpdateNotifier(msg.ID, nil, "", signatures, config.SigNotifierTTL)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("fail to update notifier")
 	}

--- a/keysign/signature_notifier_test.go
+++ b/keysign/signature_notifier_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/go-tss/config"
 	"github.com/zeta-chain/go-tss/conversion"
 
 	"github.com/zeta-chain/go-tss/common"
@@ -163,7 +164,7 @@ func TestSignatureNotifierBroadcastFirst(t *testing.T) {
 	notifier := n1.notifiers[messageID]
 	n1.notifierLock.Unlock()
 	assert.False(t, notifier.readyToProcess())
-	assert.Equal(t, defaultNotifierTTL, notifier.ttl)
+	assert.Equal(t, config.SigNotifierTTL, notifier.ttl)
 
 	sig, err := n1.WaitForSignature(messageID, [][]byte{buf}, poolPubKey, time.Second*30, sigChan)
 	assert.NoError(t, err)

--- a/keysign/signature_notifier_test.go
+++ b/keysign/signature_notifier_test.go
@@ -95,58 +95,64 @@ func TestSignatureNotifierHappyPath(t *testing.T) {
 }
 
 func TestSignatureNotifierBroadcastFirst(t *testing.T) {
-	logger := zerolog.Nop()
+	conversion.SetupBech32Prefix()
 
-	poolPubKey := `thorpub1addwnpepq0ul3xt882a6nm6m7uhxj4tk2n82zyu647dyevcs5yumuadn4uamqx7neak`
+	logger := zerolog.New(zerolog.NewConsoleWriter(zerolog.ConsoleTestWriter(t)))
+
+	poolPubKey := "thorpub1addwnpepq0ul3xt882a6nm6m7uhxj4tk2n82zyu647dyevcs5yumuadn4uamqx7neak"
 	messageToSign := "yhEwrxWuNBGnPT/L7PNnVWg7gFWNzCYTV+GuX3tKRH8="
+
 	buf, err := base64.StdEncoding.DecodeString(messageToSign)
 	assert.NoError(t, err)
+
 	messageID, err := common.MsgToHashString(buf)
 	assert.NoError(t, err)
+
 	id1 := tnet.RandIdentityOrFatal(t)
 	id2 := tnet.RandIdentityOrFatal(t)
 	id3 := tnet.RandIdentityOrFatal(t)
-	mn := mocknet.New()
-	// add peers to mock net
 
+	mn := mocknet.New()
+
+	// add peers to mock net
 	a1 := tnet.RandLocalTCPAddress()
 	a2 := tnet.RandLocalTCPAddress()
 	a3 := tnet.RandLocalTCPAddress()
 
 	h1, err := mn.AddPeer(id1.PrivateKey(), a1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p1 := h1.ID()
+	require.NoError(t, err)
+
 	h2, err := mn.AddPeer(id2.PrivateKey(), a2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	p2 := h2.ID()
+	require.NoError(t, err)
+
 	h3, err := mn.AddPeer(id3.PrivateKey(), a3)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	p1 := h1.ID()
+	p2 := h2.ID()
 	p3 := h3.ID()
-	if err := mn.LinkAll(); err != nil {
-		t.Error(err)
-	}
-	if err := mn.ConnectAllButSelf(); err != nil {
-		t.Error(err)
-	}
+
+	require.NoError(t, mn.LinkAll())
+	require.NoError(t, mn.ConnectAllButSelf())
+
 	n1 := NewSignatureNotifier(h1, logger)
-	n2 := NewSignatureNotifier(h2, logger)
-	n3 := NewSignatureNotifier(h3, logger)
 	assert.NotNil(t, n1)
+
+	n2 := NewSignatureNotifier(h2, logger)
 	assert.NotNil(t, n2)
+
+	n3 := NewSignatureNotifier(h3, logger)
 	assert.NotNil(t, n3)
+
 	sigFile := "../test_data/signature_notify/sig1.json"
+
 	content, err := os.ReadFile(sigFile)
 	assert.NoError(t, err)
 	assert.NotNil(t, content)
+
 	var signature tsslibcommon.SignatureData
-	err = json.Unmarshal(content, &signature)
-	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(content, &signature))
+
 	sigChan := make(chan string)
 
 	assert.NotContains(t, n1.notifiers, messageID)
@@ -166,9 +172,9 @@ func TestSignatureNotifierBroadcastFirst(t *testing.T) {
 	assert.False(t, notifier.readyToProcess())
 	assert.Equal(t, config.SigNotifierTTL, notifier.ttl)
 
-	sig, err := n1.WaitForSignature(messageID, [][]byte{buf}, poolPubKey, time.Second*30, sigChan)
-	assert.NoError(t, err)
-	assert.NotNil(t, sig)
+	sig, err := n1.WaitForSignature(messageID, [][]byte{buf}, poolPubKey, config.SigNotifierTTL, sigChan)
+	require.NoError(t, err)
+	require.NotNil(t, sig)
 
 	n1.notifierLock.Lock()
 	assert.NotContains(t, n1.notifiers, messageID)

--- a/p2p/communication.go
+++ b/p2p/communication.go
@@ -87,7 +87,7 @@ func NewCommunication(
 		streamCount:      0,
 		BroadcastMsgChan: make(chan *messages.BroadcastMsgChan, 1024),
 		externalAddr:     externalAddr,
-		streamMgr:        NewStreamManager(logger, config.StreamManagerMaxAgeBeforeCleanup),
+		streamMgr:        NewStreamManager(logger, config.StreamExcessTTL),
 		whitelistedPeers: whitelistedPeers,
 	}, nil
 }

--- a/p2p/communication.go
+++ b/p2p/communication.go
@@ -22,12 +22,10 @@ import (
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/zeta-chain/go-tss/config"
 	"github.com/zeta-chain/go-tss/logs"
 	"github.com/zeta-chain/go-tss/messages"
 )
-
-// TimeoutConnecting maximum time for wait for peers to connect
-const TimeoutConnecting = 20 * time.Second
 
 // Message that get transfer across the wire
 type Message struct {
@@ -145,7 +143,7 @@ func (c *Communication) writeToStream(pid peer.ID, msg []byte, msgID string) err
 
 	c.logger.Debug().Stringer(logs.Peer, pid).Msg("Connecting to peer")
 
-	ctx, cancel := context.WithTimeout(context.Background(), TimeoutConnecting)
+	ctx, cancel := context.WithTimeout(context.Background(), config.StreamTimeoutConnect)
 	defer cancel()
 
 	stream, err := c.host.NewStream(ctx, pid, ProtocolTSS)
@@ -383,7 +381,7 @@ func (c *Communication) connectToBootstrapPeers() error {
 		}
 
 		errGroup.Go(func() error {
-			ctx, cancel := context.WithTimeout(context.Background(), TimeoutConnecting)
+			ctx, cancel := context.WithTimeout(context.Background(), config.StreamTimeoutConnect)
 			defer cancel()
 
 			if err := c.host.Connect(ctx, *pi); err != nil {

--- a/p2p/party_coordinator.go
+++ b/p2p/party_coordinator.go
@@ -43,7 +43,6 @@ func NewPartyCoordinator(host host.Host, timeout time.Duration, logger zerolog.L
 
 	// if no timeout is given, default to 10 seconds
 	if timeout == 0 {
-		// TODO MOVE to const
 		timeout = 10 * time.Second
 	}
 
@@ -256,8 +255,7 @@ func (pc *PartyCoordinator) sendRequestToLeader(msg *messages.JoinPartyLeaderCom
 func (pc *PartyCoordinator) sendMsgToPeer(msgID string, pid peer.ID, payload []byte, needResponse bool) error {
 	const protoID = ProtocolJoinPartyWithLeader
 
-	// TODO MOVE (use config.StreamTimeoutConnect)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*4)
+	ctx, cancel := context.WithTimeout(context.Background(), config.StreamTimeoutConnect)
 	defer cancel()
 
 	pc.logger.Debug().Msgf("try to open stream to (%s) ", pid)

--- a/p2p/party_coordinator.go
+++ b/p2p/party_coordinator.go
@@ -19,10 +19,12 @@ import (
 	"github.com/zeta-chain/go-tss/messages"
 )
 
+const NotificationSigReceived = "signature received"
+
 var (
 	ErrJoinPartyTimeout = errors.New("fail to join party, timeout")
 	ErrLeaderNotReady   = errors.New("leader not reachable")
-	ErrSignReceived     = errors.New("signature received")
+	ErrSigReceived      = errors.New(NotificationSigReceived)
 	ErrNotActiveSigner  = errors.New("not active signer")
 	ErrSigGenerated     = errors.New("signature generated")
 )
@@ -345,9 +347,8 @@ func (pc *PartyCoordinator) joinPartyMember(
 	close(done)
 	wg.Wait()
 
-	// TODO MOVE to const
-	if sigNotify == "signature received" {
-		return nil, ErrSignReceived
+	if sigNotify == NotificationSigReceived {
+		return nil, ErrSigReceived
 	}
 
 	if peerGroup.getLeaderResponse() == nil {
@@ -405,9 +406,8 @@ func (pc *PartyCoordinator) joinPartyLeader(
 		sigNotify = result
 	}
 
-	// TODO MOVE to const
-	if sigNotify == "signature received" {
-		return nil, ErrSignReceived
+	if sigNotify == NotificationSigReceived {
+		return nil, ErrSigReceived
 	}
 
 	allPeers := peerGroup.getAllPeers()

--- a/p2p/party_coordinator.go
+++ b/p2p/party_coordinator.go
@@ -55,7 +55,7 @@ func NewPartyCoordinator(host host.Host, timeout time.Duration, logger zerolog.L
 		timeout:    timeout,
 		peersGroup: make(map[string]*peerStatus),
 		mu:         &sync.Mutex{},
-		streamMgr:  NewStreamManager(logger, config.StreamManagerMaxAgeBeforeCleanup),
+		streamMgr:  NewStreamManager(logger, config.StreamExcessTTL),
 	}
 
 	host.SetStreamHandler(ProtocolJoinPartyWithLeader, pc.HandleStreamWithLeader)

--- a/p2p/stream_manager.go
+++ b/p2p/stream_manager.go
@@ -39,10 +39,12 @@ type streamItem struct {
 }
 
 // NewStreamManager StreamManager constructor.
-func NewStreamManager(logger zerolog.Logger) *StreamManager {
+func NewStreamManager(logger zerolog.Logger, maxAgeBeforeCleanup time.Duration) *StreamManager {
 	// The max age before cleanup for unused streams
 	// Could be moved to an constructor argument in the future.
-	const maxAgeBeforeCleanup = time.Minute
+	if maxAgeBeforeCleanup == 0 {
+		maxAgeBeforeCleanup = time.Minute
+	}
 
 	sm := &StreamManager{
 		streams:             make(map[string]streamItem),

--- a/p2p/stream_manager_test.go
+++ b/p2p/stream_manager_test.go
@@ -149,7 +149,7 @@ func TestReadPayload(t *testing.T) {
 
 func TestStreamManager(t *testing.T) {
 	// ARRANGE
-	streamManager := NewStreamManager(zerolog.New(zerolog.NewTestWriter(t)))
+	streamManager := NewStreamManager(zerolog.New(zerolog.NewTestWriter(t)), 0)
 
 	streamA := mocks.NewStream(t)
 	streamB := mocks.NewStream(t)

--- a/tss/keysign.go
+++ b/tss/keysign.go
@@ -96,7 +96,7 @@ func (t *Server) generateSignature(
 
 	if errJoinParty != nil {
 		// we received the signature from waiting for signature
-		if errors.Is(errJoinParty, p2p.ErrSignReceived) {
+		if errors.Is(errJoinParty, p2p.ErrSigReceived) {
 			return keysign.Response{}, errJoinParty
 		}
 
@@ -328,7 +328,7 @@ func (t *Server) KeySign(req keysign.Request) (keysign.Response, error) {
 			t.logger.Error().Err(errWait).Msg("waitForSignatures returned error")
 		default:
 			// we received an valid signature
-			sigChan <- "signature received"
+			sigChan <- p2p.NotificationSigReceived
 			t.logger.Debug().
 				Str(logs.MsgID, msgID).
 				Stringer(logs.Peer, receivedSig.Blame).
@@ -360,7 +360,7 @@ func (t *Server) KeySign(req keysign.Request) (keysign.Response, error) {
 		return receivedSig, nil
 	}
 	// for this round, we are not the active signer
-	if errors.Is(errGen, p2p.ErrSignReceived) || errors.Is(errGen, p2p.ErrNotActiveSigner) {
+	if errors.Is(errGen, p2p.ErrSigReceived) || errors.Is(errGen, p2p.ErrNotActiveSigner) {
 		t.updateKeySignResult(receivedSig, keysignTime)
 		return receivedSig, nil
 	}


### PR DESCRIPTION
This PR refactors all hard-coded time/interval/ttl/duration and resource constants in `config/const.go`.

This unification makes the code more transparent and simpler. It also reuses values across similar code-paths. 

**Other improvements**
- Cut stream connect time form 20s to 10s
- Improve joinPartyMember. Now it skips an unnecessary `sleep(500ms)`

Closes https://github.com/zeta-chain/go-tss/issues/56
Related https://github.com/zeta-chain/node/pull/3843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Centralized configuration of timeouts, intervals, and resource limits for stream and signature operations, allowing for easier adjustment and consistency across the application.

- **Refactor**
  - Replaced hardcoded timeout and resource limit values with configurable parameters.
  - Improved logging with structured fields and unified notification constants for signature receipt.
  - Updated retry mechanisms to use ticker-based intervals for better efficiency and clarity.
  - Enhanced cleanup logging and consistent use of configuration values in signature notifier and stream management.
  - Unified error and notification constants for signature events across components.

- **Tests**
  - Updated tests to use new configuration-driven timeout values and revised constructor arguments to match refactored functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->