### PR TITLE
feat: add more logs

### DIFF
--- a/keysign/signature_notifier.go
+++ b/keysign/signature_notifier.go
@@ -217,7 +217,11 @@ func (s *SignatureNotifier) sendOneMsgToPeer(m *signatureItem) error {
 
 	ack := make([]byte, expectedResponseSize)
 	if _, err := stream.Read(ack); err != nil {
-		return errors.Wrapf(err, "failed to read response from stream")
+		return errors.Wrapf(
+			err,
+			"failed to read response from stream (timeout: %s)",
+			config.SigNotifierAckTimeout.String(),
+		)
 	}
 
 	return err

--- a/logs/fields.go
+++ b/logs/fields.go
@@ -7,8 +7,8 @@ const (
 	Component = "component"
 	MsgID     = "msg_id"
 	Peer      = "peer"
-	Host      = "host"
-	Leader    = "leader"
+	Host      = "p2p_host"
+	Leader    = "p2p_leader"
 	Latency   = "latency"
 )
 

--- a/p2p/party_coordinator.go
+++ b/p2p/party_coordinator.go
@@ -385,7 +385,7 @@ func (pc *PartyCoordinator) joinPartyMember(
 	case peerGroup.getLeaderResponse().Type == messages.JoinPartyLeaderComm_Success:
 		return pIDs, nil
 	default:
-		return pIDs, ErrJoinPartyTimeout
+		return pIDs, errors.Wrapf(ErrJoinPartyTimeout, "(timeout: %s)", pc.timeout.String())
 	}
 }
 

--- a/tss/keysign.go
+++ b/tss/keysign.go
@@ -340,7 +340,7 @@ func (t *Server) KeySign(req keysign.Request) (keysign.Response, error) {
 			t.logger.Debug().
 				Str(logs.MsgID, msgID).
 				Stringer(logs.Peer, receivedSig.Blame).
-				Msg("Keysign:received signature")
+				Msg("Keysign: received signature")
 		}
 	}()
 

--- a/tss/keysign.go
+++ b/tss/keysign.go
@@ -121,8 +121,13 @@ func (t *Server) generateSignature(
 		t.logger.Error().
 			Err(errJoinParty).
 			Str(logs.MsgID, msgID).
+			Str(logs.Peer, t.p2pCommunication.GetLocalPeerID()).
+			Stringer(logs.Leader, leader).
+			Any("peers_count", len(onlinePeers)).
 			Any("peers", onlinePeers).
-			Msg("Failed to form keysign party with online peers")
+			Int64("block_height", req.BlockHeight).
+			Any("blame_leader", blameLeader).
+			Msg("Failed to form keysign party")
 
 		return keysign.Response{
 			Status: common.Fail,
@@ -325,14 +330,17 @@ func (t *Server) KeySign(req keysign.Request) (keysign.Response, error) {
 		case errors.Is(errWait, p2p.ErrSigGenerated):
 			// ok, we generate the signature ourselves
 		case errWait != nil:
-			t.logger.Error().Err(errWait).Msg("waitForSignatures returned error")
+			t.logger.Error().
+				Str(logs.MsgID, msgID).
+				Err(errWait).
+				Msg("Keysign: waitForSignatures failed")
 		default:
 			// we received an valid signature
 			sigChan <- p2p.NotificationSigReceived
 			t.logger.Debug().
 				Str(logs.MsgID, msgID).
 				Stringer(logs.Peer, receivedSig.Blame).
-				Msg("received signature")
+				Msg("Keysign:received signature")
 		}
 	}()
 


### PR DESCRIPTION
This will help debug potential issues in live networks. Also, `host` renames to `p2p_host` to avoid collission with machine's host name 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Error messages now include timeout durations for improved clarity when operations time out.
- **Style**
  - Log messages updated for greater detail and consistency, including additional contextual information such as peer IDs and message IDs.
  - Log field names changed from "host" and "leader" to "p2p_host" and "p2p_leader" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->