### PR TITLE
fix: use strict-weak ordering for message to sign

### DIFF
--- a/tss/keysign.go
+++ b/tss/keysign.go
@@ -302,7 +302,7 @@ func (t *Server) KeySign(req keysign.Request) (keysign.Response, error) {
 			return false
 		}
 
-		return ma.Cmp(mb) >= 0
+		return ma.Cmp(mb) > 0
 	})
 
 	threshold, err := conversion.GetThreshold(len(localStateItem.ParticipantKeys))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the sorting logic for signing messages to ensure a more accurate and consistent order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->